### PR TITLE
If comparison typo (should be = not ==)

### DIFF
--- a/snapcraft-assets/snap/command-chain/alsa-launch
+++ b/snapcraft-assets/snap/command-chain/alsa-launch
@@ -50,13 +50,13 @@ EOF
 }
 
 setup_alsa_override() {
-  if [ "$SNAP_ARCH" == "amd64" ]; then
+  if [ "$SNAP_ARCH" = "amd64" ]; then
     ALSA_ARCH_TRIPLET="x86_64-linux-gnu"
-  elif [ "$SNAP_ARCH" == "armhf" ]; then
+  elif [ "$SNAP_ARCH" = "armhf" ]; then
     ALSA_ARCH_TRIPLET="arm-linux-gnueabihf"
-  elif [ "$SNAP_ARCH" == "arm64" ]; then
+  elif [ "$SNAP_ARCH" = "arm64" ]; then
     ALSA_ARCH_TRIPLET="aarch64-linux-gnu"
-  elif [ "$SNAP_ARCH" == "ppc64el" ]; then
+  elif [ "$SNAP_ARCH" = "ppc64el" ]; then
     ALSA_ARCH_TRIPLET="powerpc64le-linux-gnu"
   else
     ALSA_ARCH_TRIPLET="$SNAP_ARCH-linux-gnu"


### PR DESCRIPTION
I'm getting the following errors which, I believe, are just th result of a typo:
```
/snap/mycroft/x1/snap/command-chain/alsa-launch: 53: [: amd64: unexpected operator
/snap/mycroft/x1/snap/command-chain/alsa-launch: 55: [: amd64: unexpected operator
/snap/mycroft/x1/snap/command-chain/alsa-launch: 57: [: amd64: unexpected operator
/snap/mycroft/x1/snap/command-chain/alsa-launch: 59: [: amd64: unexpected operator
```

Full disclosure, i haven't tested the effects of correcting this typo...