### PR TITLE
Make the popup "switch to ALSA" dialogue a bit nicer

### DIFF
--- a/snapcraft-assets/snap/command-chain/alsa-launch
+++ b/snapcraft-assets/snap/command-chain/alsa-launch
@@ -7,44 +7,53 @@ else
 fi
 
 popup() {
-  TEXT="$SNAP_READABLE_NAME requires access to the ALSA system.
+  TEXT="$SNAP_READABLE_NAME may have improved audio quality if granted permission to access the ALSA audio system.
 
-You need grant the ALSA permission to the Snap Package by running the following
-command in a terminal, or use the Snap Store or Software Centre app to grant the
-permission.
+If you experience audio problems, you may wish to grant this access by using the Software Centre or the Snap Store to add the 'alsa' permission to $SNAP_READABLE_NAME. It is safe to continue without doing so.
 
-You can also try to use Pulseaudio instead but this may lead to strange issues.
+You can also grant this permission by running the following command in a Terminal window:
 
-    $ sudo snap connect $SNAP_NAME:alsa
+<tt>sudo snap connect $SNAP_NAME:alsa</tt>
+
+If you choose to continue and later wish to change your mind, you can remove the file <tt>$SNAP_USER_DATA/Always use PulseAudio</tt>.
 "
+PLAIN=$(sed 's/<[^>]*>//g' <<< $TEXT)
+PLAINWRAPPED=$(echo -e "$PLAIN" | fold -w 70 -s -)
+
   if snapctl is-connected desktop; then
     yad --center \
-        --title="$SNAP_READABLE_NAME cannot access ALSA" \
+        --title="Configuring $SNAP_READABLE_NAME audio system" \
         --text="$TEXT" \
-        --button="Retest":255 \
-        --button="Always Use PulseAudio":2
-        --button="Use PulseAudio This Time":1 \
-        --button="Cancel":0
+        --button="Permission has been granted":255 \
+        --button="Start and ask next time":1 \
+        --button="Start and don't ask again":2 \
+        --button=gtk-cancel:0 \
+        --borders=12 \
+        --image=audio-volume-high-symbolic \
+        --width=100
+
     return $?
   elif [ $SHLVL -gt 1 ]; then
-    echo <<EOF
-$TEXT
+    echo "$PLAINWRAPPED"
+    cat <<EOF
 
-Type r to retest,
-Type p to Use PulseAudio this time
-Type a to Always use PulseAudio, or
-Type c to Cancel (default):
+Type [p] to re-test after granting [p]ermission,
+     [s] to [s]tart and not ask again,
+     [a] to start and [a]sk again next time, or
+     [c] to [c]ancel (default)
 
 EOF
-    read -n 1 -p "retest|pulseaudio|always|[cancel]? " response
-    case response in
-      R|Retest|r|retest)
-        return 255
-        ;;
-      A|Always|a|always)
+
+    read -n 1 -p "permission | start | ask | [cancel] > " response
+
+    case $response in
+      S|Start|s|start)
         return 2
         ;;
-      P|Pulseaudio|PulseAudio|p|pulseaudio)
+      P|p|Permission|permission|R|r|Retest|retest)
+        return 255
+        ;;
+      A|Ask|a|ask)
         return 1
         ;;
       *)
@@ -102,8 +111,8 @@ if [ -n "$ALWAYS_USE_PULSEAUDIO" ] && [ "$ALWAYS_USE_PULSEAUDIO" -eq 1 ]; then
 
 else
 
-  if ! env LANG=C snapctl is-connected alsa 2>&1 | grep 'has no plug or slot named "alsa"' >/dev/null; then
-    ret=2
+  if ! env LANG=C snapctl is-connected alsa 2>&1 | grep -q 'has no plug or slot named "alsa"'; then
+    ret=255
     while [ $ret = 255 ] && ! snapctl is-connected alsa; do
       popup
       ret=$?
@@ -115,7 +124,7 @@ else
     case $ret in
       1)
         echo "Setting ALSA to always route through PulseAudio"
-        echo "ALWAYS_USE_PULSEAUDIO=1" > "$SNAP_USER_DATA/.snapcraft-alsa"
+        echo "ALWAYS_USE_PULSEAUDIO=1" > "$SNAP_USER_DATA/Always use PulseAudio"
         setup_alsa_override
         ;;
       2)

--- a/snapcraft-assets/snap/command-chain/alsa-launch
+++ b/snapcraft-assets/snap/command-chain/alsa-launch
@@ -89,7 +89,10 @@ setup_alsa_override() {
 }
 
 if [ -f "$SNAP_USER_DATA/.snapcraft-alsa" ]; then
-  . "$SNAP_USER_DATA/.snapcraft-alsa"
+  mv "$SNAP_USER_DATA/.snapcraft-alsa" "$SNAP_USER_DATA/Always use PulseAudio"
+fi
+if [ -f "$SNAP_USER_DATA/Always use PulseAudio" ]; then
+  . "$SNAP_USER_DATA/Always use PulseAudio"
 fi
 
 if [ -n "$ALWAYS_USE_PULSEAUDIO" ] && [ "$ALWAYS_USE_PULSEAUDIO" -eq 1 ]; then

--- a/snapcraft-assets/snap/command-chain/alsa-launch
+++ b/snapcraft-assets/snap/command-chain/alsa-launch
@@ -7,7 +7,7 @@ else
 fi
 
 popup() {
-  TEXT="$SNAP_READABLE_NAME may have improved audio quality if granted permission to access the ALSA audio system.
+  TEXT="$SNAP_READABLE_NAME may have better audio device support if granted permission to access the ALSA audio system.
 
 If you experience audio problems, you may wish to grant this access by using the Software Centre or the Snap Store to add the 'alsa' permission to $SNAP_READABLE_NAME. It is safe to continue without doing so.
 


### PR DESCRIPTION
Change the popup dialogue text to be framed as "if you have problems, switch to alsa" rather than "if you want problems, stay with pulseaudio". Also tidy up the dialogue box and format it properly (and fix a bug where it was missing a backslash in the `yad` command line), and frame responses to skew towards "do what I'm doing now", and word in terms of "Don't ask again" which is familiar from other dialogue types. Make the "always use PulseAudio" file be visible, so that if a user wants to undo their decision but can't remember how, they stand a chance of finding the file by poking around in `snap/APPNAME`.

I have not been able to test that this actually does the right thing, because doing so requires building and installing a whole snap, so that will need checking still of course.