### PR TITLE
Use bash instead of /bin/sh

### DIFF
--- a/snapcraft-assets/snap/command-chain/alsa-launch
+++ b/snapcraft-assets/snap/command-chain/alsa-launch
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ -f "$SNAP/meta/gui/$SNAP_NAME.desktop" ]; then
   SNAP_READABLE_NAME="$(awk 'BEGIN { FS="=" }; /^Name=/ { print $2 }' "$SNAP/meta/gui/$SNAP_NAME.desktop")"


### PR DESCRIPTION
Bash is in core; there is literally no reason to use /bin/sh because it's loads worse and there is no serious performance implication here.